### PR TITLE
Change FloatPat to have a Double instead of a Float

### DIFF
--- a/freest/src/Syntax/Expression.hs
+++ b/freest/src/Syntax/Expression.hs
@@ -27,7 +27,7 @@ data Pat
   | ConsPat Span Identifier [Pat]
   | TuplePat Span [Pat]
   | IntPat Span Int 
-  | FloatPat Span Float 
+  | FloatPat Span Double 
   | CharPat Span Char 
   | StringPat Span String 
   | AsPat Span Variable Pat


### PR DESCRIPTION
Changes the type inside FloatPat to Double to match the type that the parser parses for the float literals.